### PR TITLE
Stop installing pyafipws, just use a downloaded branch, so we have the templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN mkdir /config
 RUN apt-get update && apt-get install -y inkscape && apt-get clean
 COPY /config/requirements.txt /config/
 RUN pip install --no-cache-dir -r /config/requirements.txt
-# Workaround to install pyafipws in python3 (first instally m2crypto pinned to the version that actually builds)
+# Workaround to use pyafipws in python3 (first instally m2crypto pinned to the version that actually builds)
 RUN pip install m2crypto==0.33.0
-RUN wget https://raw.githubusercontent.com/reingart/pyafipws/master/requirements.txt -O /tmp/req_pyafipws.txt && pip install --no-cache-dir -r /tmp/req_pyafipws.txt
-RUN pip install https://github.com/PyAr/pyafipws/archive/py3k.zip
+RUN wget https://github.com/PyAr/pyafipws/archive/py3k.zip && unzip py3k.zip && mv pyafipws-py3k/ pyafipws/
+RUN pip install --no-cache-dir -r /code/website/pyafipws/requirements.txt
 
 # Copy code
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,14 @@ COPY /config/requirements.txt /config/
 RUN pip install --no-cache-dir -r /config/requirements.txt
 # Workaround to use pyafipws in python3 (first instally m2crypto pinned to the version that actually builds)
 RUN pip install m2crypto==0.33.0
-RUN wget https://github.com/PyAr/pyafipws/archive/py3k.zip && unzip py3k.zip && mv pyafipws-py3k/ pyafipws/
-RUN pip install --no-cache-dir -r /code/website/pyafipws/requirements.txt
 
 # Copy code
 WORKDIR /code
 COPY . /code/
 
+# Set working dir
 WORKDIR /code/website
+
+# Bring pyafipws branch and install it's dependencies
+RUN wget https://github.com/PyAr/pyafipws/archive/py3k.zip && unzip py3k.zip && mv pyafipws-py3k pyafipws
+RUN pip install --no-cache-dir -r /code/website/pyafipws/requirements.txt


### PR DESCRIPTION
I created this PR after having production "fixed" doing the following sequence:

```
root@production-admin-asoc-members-889fcb96b-crw82:/code/website# history
    1  wget https://github.com/PyAr/pyafipws/archive/py3k.zip
    2  mv /usr/local/lib/python3.6/site-packages/pyafipws/ /usr/local/lib/python3.6/site-packages/pyafipws--void
    3  ./manage.py generate_member_invoices 1
    4  unzip py3k.zip
    5  mv pyafipws-py3k/ pyafipws
    6  ./manage.py generate_member_invoices 1
    7  history
```

Step 1 is reflected in the Dockerfile. Step 2 and 3 is just to verify that after that it will not use the installed lib. Steps 4 and 5 are reflected in the Dockerfile. Step 6 is to check that everything is fine now. Step 7 is what produced the list above...