### PR TITLE
Mejoras en las páginas de solicitud de alta

### DIFF
--- a/website/members/models.py
+++ b/website/members/models.py
@@ -248,6 +248,7 @@ class Category(TimeStampedModel):
         (BENEFACTOR_GOLD, BENEFACTOR_GOLD),
         (BENEFACTOR_SILVER, BENEFACTOR_SILVER),
     )
+    HUMAN_CATEGORIES = {ACTIVE, SUPPORTER, STUDENT, COLLABORATOR, TEENAGER}
 
     class Meta:
         verbose_name_plural = "categories"

--- a/website/members/templates/members/signup_org_form.html
+++ b/website/members/templates/members/signup_org_form.html
@@ -1,13 +1,51 @@
 {% extends "members/signup_initial.html" %}
 {% load crispy_forms_tags %}
 {% block inner-content %}
-    <p>Si querés el detalle completo podes consultarlo en la página 5 de nuestro estatuto:
-            <a href="http://bit.ly/pyar-estatuto">http://bit.ly/pyar-estatuto</a>
-        </p>
-    <form method="POST" novalidate  enctype="multipart/form-data">
-        {% crispy form %}
-        <a class="btn btn-default" href="{% url 'signup' %}">Volver</a>
-        <input type="submit" class="btn btn-success" value="Enviar solicitud" />
-    </form>
+
+<p>
+De la página 5 de nuestro <a href="http://bit.ly/pyar-estatuto">Estatuto</a>:
+</p>
+<p>
+Serán asociados benefactores las personas físicas o jurídicas que contribuyan
+prestando servicios o aportes significativos a la Asociación, reconocidos por la Comisión
+Directiva e incorporados, previa su aceptación como socios por la misma. Apoyarán
+económicamente y de manera especial a la entidad abonando cuota social u otras
+contribuciones que se establezcan. Podrán ser designados para integrar las subcomisiones
+que se creen. Tendrán voz pero no voto en las asambleas, y no podrán ser elegidos para
+integrar los órganos sociales. Los socios activos o adherentes que, voluntariamente abonen
+de forma regular aportes significativos adicionales a la cuota social, a juicio de la Comisión
+Directiva, podrán pertenecer a esta categoría, sin que esta denominación les otorgue
+privilegio alguno, por lo tanto, no implica reconocer derechos ni imponer obligaciones.
+</p>
+
+<div class="row">
+    {% for cat in categories %}
+    <div class="col-sm-4">
+        <div class="panel panel-info">
+            <div class="panel-heading">
+                Socio {{ cat.name }}
+            </div>
+            <div class="panel-body">
+                {{ cat.description | linebreaks }}
+                <br/>
+                <strong>Cuota: ${{ cat.anual_fee }} anual </strong>
+            </div>
+        </div>
+    </div>
+    {% if forloop.counter|divisibleby:3 %}
+        </div><div class="row">
+    {% endif %}
+    {% endfor %}
 </div>
+
+<p>
+Más información sobre los distintos beneficios en <a href="https://github.com/PyAr/asoc/raw/master/folleter%C3%ADa/Propuesta%20Empresas%20Benefactoras.pdf">este documento</a>.
+</p>
+
+<form method="POST" novalidate  enctype="multipart/form-data">
+    {% crispy form %}
+    <a class="btn btn-default" href="{% url 'signup' %}">Volver</a>
+    <input type="submit" class="btn btn-success" value="Enviar solicitud" />
+</form>
+
 {% endblock %}

--- a/website/members/templates/members/signup_person_form.html
+++ b/website/members/templates/members/signup_person_form.html
@@ -24,8 +24,9 @@
                     Socio {{ cat.name }}
                 </div>
                 <div class="panel-body">
-                    {{ cat.description}}<br>
-                    <strong>Cuota:  ${{ cat.fee }} Mensual </strong>
+                    {{ cat.description | linebreaks }}
+                    <br/>
+                    <strong>Cuota: ${{ cat.fee }} mensual </strong>
                 </div>
             </div>
         </div>

--- a/website/members/tests.py
+++ b/website/members/tests.py
@@ -92,6 +92,18 @@ class SignupPagesTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'members/signup_person_form.html')
 
+    def test_signup_person_page_linebreaks(self):
+        # test that it respectes the line breaks of the original description
+        Category.objects.create(name='Activo', description='foo\nbar\n', fee=50)
+        response = self.client.get(reverse('signup_person'))
+        self.assertIn(b'foo<br>bar', response.content)
+
+    def test_signup_person_page_categories(self):
+        # test that it show only human-related categories
+        cat = Category.objects.create(name=Category.BENEFACTOR_GOLD, description='', fee=500)
+        response = self.client.get(reverse('signup_person'))
+        self.assertNotIn(cat, response.context_data['categories'])
+
     def test_get_signup_org_page(self):
         response = self.client.get(reverse('signup_organization'))
         self.assertEqual(response.status_code, 200)

--- a/website/members/views.py
+++ b/website/members/views.py
@@ -43,14 +43,14 @@ class SignupPersonFormView(CreateView):
     success_url = reverse_lazy('signup_person_thankyou')
 
     def get_context_data(self, **kwargs):
-        context = super(SignupPersonFormView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         human_cats = Category.HUMAN_CATEGORIES
         context["categories"] = Category.objects.order_by('-fee').filter(name__in=human_cats)
         return context
 
     def form_invalid(self, form):
         messages.error(self.request, _("Por favor, revise los campos."))
-        return super(SignupPersonFormView, self).form_invalid(form)
+        return super().form_invalid(form)
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -75,6 +75,17 @@ class SignupOrganizationsFormView(CreateView):
     model = Organization
     template_name = 'members/signup_org_form.html'
     success_url = reverse_lazy('signup_organization_thankyou')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        human_cats = Category.HUMAN_CATEGORIES
+        context["categories"] = [
+            {
+                'name': cat.name,
+                'description': cat.description,
+                'anual_fee': cat.fee * 12,
+            } for cat in Category.objects.order_by('-fee').exclude(name__in=human_cats)]
+        return context
 
 
 class SignupPersonThankyouView(TemplateView):
@@ -388,7 +399,7 @@ class MembersListView(LoginRequiredMixin, ListView):
     }
 
     def get_queryset(self):
-        queryset = super(MembersListView, self).get_queryset()
+        queryset = super().get_queryset()
         search_value = self.request.GET.get('search', None)
         if search_value and search_value != '':
             queryset = search_filtered_queryset(queryset, self.search_fields, search_value)
@@ -434,7 +445,7 @@ class MemberDetailView(LoginRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         # Get the context from base
-        context = super(MemberDetailView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         member = self.get_object()
         today = datetime.date.today()
         debt = logic.get_debt_state(member, today.year, today.month)

--- a/website/members/views.py
+++ b/website/members/views.py
@@ -44,7 +44,8 @@ class SignupPersonFormView(CreateView):
 
     def get_context_data(self, **kwargs):
         context = super(SignupPersonFormView, self).get_context_data(**kwargs)
-        context["categories"] = Category.objects.order_by('-fee')
+        human_cats = Category.HUMAN_CATEGORIES
+        context["categories"] = Category.objects.order_by('-fee').filter(name__in=human_cats)
         return context
 
     def form_invalid(self, form):


### PR DESCRIPTION
En general:

- respetar newlines en las descripciones


En la de personas:

- Sólo categorías para humanes


En la de organizaciones:

- Mostrar las categorías

- Incluí el texto correspondiente del estatuto

- Puse un link al folleto de beneficios
