### PR TITLE
Some fixes for management commands to run ok

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ COPY . /code/
 # Set working dir
 WORKDIR /code/website
 
+# Patch SSL config so we can work with AFIP (see the following issue 
+# for more info: https://github.com/PyAr/asoc_members/issues/133 )
+RUN sed -i 's/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/' /etc/ssl/openssl.cnf
+
 # Bring pyafipws branch and install it's dependencies
 RUN wget https://github.com/PyAr/pyafipws/archive/py3k.zip && unzip py3k.zip && mv pyafipws-py3k pyafipws
 RUN pip install --no-cache-dir -r /code/website/pyafipws/requirements.txt

--- a/website/utils/afip.py
+++ b/website/utils/afip.py
@@ -55,6 +55,8 @@ def verify_service(selling_point):
     """Basic initial check that everything works with AFIP."""
     wsfev1 = _get_afip()
     last_auth_invoice = wsfev1.CompUltimoAutorizado(INVOICE_TYPE, selling_point)
+    if int(last_auth_invoice) == 0:
+        raise ValueError("Bad last auth invoice (AFIP is misbehaving)")
     print("Last authorized invoice", last_auth_invoice)
     res = wsfev1.CompConsultar(INVOICE_TYPE, last_auth_invoice, selling_point)
     print("Current status", repr(res))

--- a/website/utils/gdrive.py
+++ b/website/utils/gdrive.py
@@ -51,7 +51,7 @@ class Explorer:
     def __init__(self):
         credentials = get_credentials()
         authorized_http = credentials.authorize(httplib2.Http())
-        self.service = discovery.build('drive', 'v3', http=authorized_http)
+        self.service = discovery.build('drive', 'v3', http=authorized_http, cache_discovery=False)
 
     def create_folder(self, folder, parent):
         """Create a folder."""


### PR DESCRIPTION
Including:

- Verify that `last_auth_invoice` is not `0` or `'0'`, because (as I experimented yesterday) is an indication of AFIP being stupid, so better to get out ASAP from there.

- Added `cache_discovery=False` to Google API service discovery, which is a workaround (for the current tip version of the library, fixed in master) that leads to a lot of messages shown in the output.

- Patched OpenSSL config so we lower the verification level and we can work ok with AFIP without patching Python SSL libs.