### PR TITLE
Include a version of httplib2 that fixes a specific problem.

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,3 +1,4 @@
+httplib2>=0.22.0  # not needed directly, but 0.22.0 fixes "Cannot set verify_mode to CERT_NONE when check_hostname is enabled" problem
 certg==4.2
 certifi>=2020.4.5.1
 django-configurations==2.2


### PR DESCRIPTION
The fixed problem is 

```
  File "/usr/local/lib/python3.9/site-packages/httplib2/__init__.py", line 1577, in request
    conn = self.connections[conn_key] = connection_type(
  File "/usr/local/lib/python3.9/site-packages/httplib2/__init__.py", line 1096, in __init__
    context = _build_ssl_context(
  File "/usr/local/lib/python3.9/site-packages/httplib2/__init__.py", line 155, in _build_ssl_context
    context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
  File "/usr/local/lib/python3.9/ssl.py", line 721, in verify_mode
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```