### PR TITLE
Refactored how we get results from Mercadopago.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,8 @@ jobs:
           python-version: 3.9
       - name: Bootstrap everything
         run: |
-          pip install -U "docker-compose < 7"
+          pip install -U docker < 7  # compatibility issues; see https://github.com/docker/docker-py/issues/3194
+          pip install -U docker-compose
           docker-compose up -d
           docker-compose exec -T web pip install -r /code/config/requirements-dev.txt
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: 3.9
       - name: Bootstrap everything
         run: |
-          pip install -U docker < 7  # compatibility issues; see https://github.com/docker/docker-py/issues/3194
+          pip install -U "docker < 7"  # compatibility issues; see https://github.com/docker/docker-py/issues/3194
           pip install -U docker-compose
           docker-compose up -d
           docker-compose exec -T web pip install -r /code/config/requirements-dev.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: 3.9
       - name: Bootstrap everything
         run: |
-          pip install -U docker-compose 
+          pip install -U "docker-compose < 7"
           docker-compose up -d
           docker-compose exec -T web pip install -r /code/config/requirements-dev.txt
       - name: Run tests

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -9,7 +9,7 @@ django-storages[azure]==1.11.1
 django==3.1.14
 google-api-python-client==1.12.8
 gunicorn==20.0.4
-mercadopago==1.1.1
+mercadopago==2.2.1
 oauth2client==4.1.3
 Pillow==10.0.1
 psycopg2_binary==2.8.6

--- a/website/members/management/commands/_mp.py
+++ b/website/members/management/commands/_mp.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from mercadopago import MP
+from mercadopago import SDK
 
 LIMIT = 500
 
@@ -9,25 +9,37 @@ logger = logging.getLogger('mercadopago')
 
 
 def get_raw_mercadopago_info():
-    """Get records from Mercadopago API."""
-    mercadopago_client_id = os.getenv('MERCADOPAGO_CLIENT_ID')
-    mercadopago_client_secret = os.getenv('MERCADOPAGO_CLIENT_SECRET')
+    """Get records from Mercadopago API.
 
-    mp = MP(mercadopago_client_id, mercadopago_client_secret)
+    As different hits bring different "total" values indicated, we record what is the
+    max of those, and only stop hitting when we get no results from one of those endpoints.
+    """
     logger.debug('Connecting with mercadopago')
+    auth_token = os.getenv('MERCADOPAGO_AUTH_TOKEN')
+    mp = SDK(auth_token)
 
-    filters = {'status': 'approved'}
+    filters = {'status': 'approved', 'limit': LIMIT, 'begin_date': 'NOW-3MONTHS'}
     offset = 0
     results = []
+    max_total_exposed = 0
     while True:
-        response = mp.search_payment(filters, limit=LIMIT, offset=offset)
+        filters["offset"] = offset
+        response = mp.payment().search(filters)
         assert response['status'] == 200
+
+        quant_results = len(response['response']['results'])
+        paging = response['response']['paging']
+        max_total_exposed = max(max_total_exposed, paging["total"])
         logger.debug(
-            'Getting response from mercadopago, paging %s', response['response']['paging'])
+            'Getting response from mercadopago, len=%d paging=%s', quant_results, paging)
+
         results.extend(response['response']['results'])
-        if len(response['response']['results']) < LIMIT:
-            break
-        offset += LIMIT
+        if not response['response']['results']:
+            if paging["total"] == max_total_exposed:
+                # didn't get any result when hitting the endpoint that brings more
+                # results that any other
+                break
+        offset += quant_results
 
     logger.info('Got response from mercadopago, %d items', len(results))
     return results

--- a/website/members/management/commands/_mp.py
+++ b/website/members/management/commands/_mp.py
@@ -36,8 +36,7 @@ def get_raw_mercadopago_info():
         results.extend(response['response']['results'])
         if not response['response']['results']:
             if paging["total"] == max_total_exposed:
-                # didn't get any result when hitting the endpoint that brings more
-                # results that any other
+                # didn't get any result and reported "total" is the biggest seen so far
                 break
         offset += quant_results
 


### PR DESCRIPTION
In detail:

- updated lib version (had to change how to instantiate/authenticate the lib, which method to use and how parameters are indicated)

- increment the offset not by a hardcoded value but using the quantity of last retrieved results

- stop hitting the backend only after we get empty results of the endpoint that exposes more results (every hit indicates a different "total", so we track which is the max available)